### PR TITLE
  Fix follow list to preserve t tags when unfollowing users

### DIFF
--- a/NIP-46-INVESTIGATION.md
+++ b/NIP-46-INVESTIGATION.md
@@ -1,0 +1,323 @@
+# NIP-46 (Nostr Connect) Implementation Investigation
+
+## Overview
+
+This document investigates adding NIP-46 remote signing support to Plebs vs Zombies, allowing users to connect using remote signers (bunkers) in addition to the current NIP-07 browser extension support.
+
+## What is NIP-46?
+
+NIP-46 (Nostr Connect) is a protocol for 2-way communication between a remote signer and a Nostr client:
+- **Client**: The user-facing application (Plebs vs Zombies)
+- **Remote Signer (Bunker)**: A daemon/service that holds private keys and signs events
+- **Communication**: Uses kind 24133 events with NIP-44 encryption over Nostr relays
+
+## Current Implementation
+
+The current `nostrService.js` uses:
+- **NDK v2.5.1** with `NDKNip07Signer` for browser extensions
+- **nostr-tools v2.1.4** for utility functions
+- Direct `window.nostr` API access for signing
+
+## Implementation Requirements
+
+### 1. Connection Methods
+
+#### Option A: Bunker URL Flow (Recommended)
+```
+bunker://pubkey?relay=wss://relay.example.com&secret=randomstring&name=AppName
+```
+- User copies URL from bunker app
+- App parses URL and connects automatically
+- Most secure as bunker generates the secret
+
+#### Option B: NostrConnect URL Flow
+```
+nostrconnect://pubkey?relay=wss://relay.example.com&secret=randomstring&name=AppName
+```
+- App generates URL and displays QR/copyable link
+- User scans/pastes into bunker app
+- Requires one fewer step from user
+
+### 2. Required Dependencies
+
+Current versions are sufficient:
+- **NDK 2.5.1+**: Has `NDKNip46Signer` support
+- **nostr-tools 2.1.4+**: Has `BunkerSigner` support
+
+### 3. UI/UX Changes Needed
+
+#### Settings Page Connection Options
+Add connection method selection:
+```
+[ ] Browser Extension (NIP-07) - Currently selected
+[ ] Remote Signer (NIP-46) - New option
+```
+
+#### NIP-46 Connection Flow
+1. **Input Method Selection**:
+   - Paste bunker URL
+   - Scan QR code
+   - Manual connection details
+
+2. **Connection Status**:
+   - Connecting to bunker...
+   - Connected to: nsec.app
+   - Ready for signing
+
+3. **Connection Management**:
+   - Disconnect button
+   - Connection health indicator
+   - Relay status
+
+### 4. Technical Implementation
+
+#### A. Service Layer Updates
+
+**New file: `src/services/nip46Service.js`**
+```javascript
+import { NDKNip46Signer } from '@nostr-dev-kit/ndk';
+import { BunkerSigner } from 'nostr-tools/nip46';
+
+class Nip46Service {
+  constructor() {
+    this.signer = null;
+    this.connected = false;
+    this.bunkerPubkey = null;
+    this.relays = [];
+  }
+
+  async connectWithBunkerUrl(bunkerUrl) {
+    // Parse bunker://... URL
+    // Create NDKNip46Signer
+    // Handle connection flow
+  }
+
+  async connectWithDetails(pubkey, relays, secret) {
+    // Manual connection setup
+  }
+
+  async disconnect() {
+    // Clean disconnection
+  }
+
+  isConnected() {
+    return this.connected && this.signer;
+  }
+
+  async signEvent(event) {
+    if (!this.signer) throw new Error('Not connected');
+    return await this.signer.signEvent(event);
+  }
+}
+```
+
+#### B. NostrService Integration
+
+**Modified `src/services/nostrService.js`**
+```javascript
+import nip46Service from './nip46Service.js';
+
+class NostrService {
+  constructor() {
+    // ... existing code ...
+    this.signingMethod = 'nip07'; // 'nip07' | 'nip46'
+    this.nip46Service = nip46Service;
+  }
+
+  async initialize() {
+    let signer = null;
+    
+    if (this.signingMethod === 'nip07' && typeof window.nostr !== 'undefined') {
+      signer = new NDKNip07Signer();
+    } else if (this.signingMethod === 'nip46' && this.nip46Service.isConnected()) {
+      signer = this.nip46Service.signer;
+    }
+    
+    this.ndk = new NDK({
+      explicitRelayUrls: this.relays,
+      signer: signer
+    });
+    
+    await this.ndk.connect();
+  }
+
+  async signEvent(event) {
+    if (this.signingMethod === 'nip07') {
+      return await window.nostr.signEvent(event);
+    } else if (this.signingMethod === 'nip46') {
+      return await this.nip46Service.signEvent(event);
+    }
+    throw new Error('No signing method available');
+  }
+}
+```
+
+#### C. UI Components
+
+**New component: `src/components/Nip46Connection.vue`**
+```vue
+<template>
+  <div class="card">
+    <h3>Remote Signer Connection (NIP-46)</h3>
+    
+    <!-- Connection Status -->
+    <div v-if="connected" class="status-connected">
+      <span class="text-zombie-green">✅ Connected to bunker</span>
+      <button @click="disconnect">Disconnect</button>
+    </div>
+    
+    <!-- Connection Form -->
+    <div v-else class="connection-form">
+      <div class="input-group">
+        <label>Bunker URL:</label>
+        <input 
+          v-model="bunkerUrl" 
+          placeholder="bunker://..."
+          @paste="handleUrlPaste"
+        />
+      </div>
+      
+      <button @click="connect" :disabled="connecting">
+        {{ connecting ? 'Connecting...' : 'Connect' }}
+      </button>
+      
+      <div class="help-text">
+        <p>Get a bunker URL from:</p>
+        <ul>
+          <li><a href="https://nsec.app" target="_blank">nsec.app</a></li>
+          <li><a href="https://nsecbunker.com" target="_blank">nsecBunker</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+### 5. Security Considerations
+
+#### Connection Security
+- **Secret Validation**: Ensure bunker validates the secret
+- **Relay Trust**: Use trusted relays for NIP-46 communication
+- **Connection Persistence**: Store connection details securely
+
+#### Permission Model
+- **Method Permissions**: `sign_event`, `nip44_encrypt`, etc.
+- **Kind Restrictions**: Limit to specific event kinds if needed
+- **User Consent**: Clear indication when remote signing occurs
+
+### 6. User Experience Flow
+
+#### First-Time Setup
+1. User goes to Settings
+2. Selects "Remote Signer (NIP-46)" option  
+3. Chooses connection method (URL paste/QR scan)
+4. Enters bunker URL or connection details
+5. App connects and requests permissions
+6. User approves connection in bunker app
+7. Connection confirmed in Plebs vs Zombies
+
+#### Daily Usage
+1. App automatically reconnects to stored bunker
+2. When signing needed, request is sent to bunker
+3. User approves in bunker app (if required)
+4. Signed event returned to app
+5. Event published to relays
+
+### 7. Error Handling
+
+#### Connection Errors
+- Bunker unreachable
+- Invalid URL format
+- Permission denied
+- Network timeouts
+
+#### Signing Errors
+- User rejection in bunker
+- Connection lost during signing
+- Invalid event format
+
+### 8. Testing Strategy
+
+#### Development Testing
+- Mock bunker service for local testing
+- Unit tests for URL parsing
+- Integration tests with real bunkers
+
+#### User Testing
+- Test with nsec.app
+- Test with nsecBunker
+- Connection stability testing
+- Performance comparison with NIP-07
+
+## Implementation Effort Estimate
+
+### Phase 1: Core Implementation (2-3 days)
+- [ ] Create `nip46Service.js` with basic connection logic
+- [ ] Integrate with existing `nostrService.js`
+- [ ] Add connection method selection to Settings
+- [ ] Implement bunker URL parsing
+
+### Phase 2: UI Enhancement (1-2 days)
+- [ ] Create `Nip46Connection.vue` component
+- [ ] Add connection status indicators
+- [ ] Implement QR code scanning (optional)
+- [ ] Add help/documentation
+
+### Phase 3: Polish & Testing (1-2 days)
+- [ ] Error handling and user feedback
+- [ ] Connection persistence
+- [ ] Performance optimization
+- [ ] Integration testing
+
+**Total Estimate: 4-7 days**
+
+## Recommended Libraries
+
+### For NDK Implementation
+```bash
+# Already available in project
+@nostr-dev-kit/ndk: ^2.5.1  # Has NDKNip46Signer
+```
+
+### For nostr-tools Implementation
+```bash
+# Already available in project  
+nostr-tools: ^2.1.4  # Has BunkerSigner
+```
+
+### Additional Dependencies (if needed)
+```bash
+# For QR code support
+qr-code-styling: ^1.6.0-rc.1
+html5-qrcode: ^2.3.8
+```
+
+## Popular Bunker Services
+
+### For Testing
+- **nsec.app**: Web-based bunker service
+- **nsecBunker**: Self-hosted option
+- **Amber (Android)**: Mobile bunker app
+
+### Production Considerations
+- Most users will use nsec.app initially
+- Power users may run their own bunkers
+- Mobile users may prefer Amber
+
+## Conclusion
+
+Adding NIP-46 support to Plebs vs Zombies is technically feasible with the current dependency versions. The implementation would provide users with an alternative to browser extensions, especially valuable for:
+
+1. **Mobile users** who can't install browser extensions
+2. **Security-conscious users** who prefer remote key storage
+3. **Power users** who want more control over their signing setup
+
+The estimated implementation effort is moderate (4-7 days) and would significantly improve accessibility and security options for users.
+
+## Next Steps
+
+1. **Prototype**: Create basic NIP-46 connection proof-of-concept
+2. **Design Review**: Finalize UI/UX design with stakeholders  
+3. **Implementation**: Follow the phased approach outlined above
+4. **Testing**: Comprehensive testing with real bunker services
+5. **Documentation**: User guide for NIP-46 setup and usage

--- a/src/App.vue
+++ b/src/App.vue
@@ -223,19 +223,21 @@
             </div>
           </label>
           
-          <label class="flex items-start gap-4 p-4 border border-gray-700 rounded-lg cursor-pointer hover:bg-gray-800 transition-colors">
+          <label class="flex items-start gap-4 p-4 border border-gray-600 rounded-lg opacity-50 cursor-not-allowed transition-colors">
             <input 
               type="radio" 
               value="nip46" 
               v-model="loginSigningMethod" 
-              class="w-5 h-5 text-zombie-green focus:ring-zombie-green mt-0.5"
+              disabled
+              class="w-5 h-5 text-gray-500 mt-0.5 cursor-not-allowed"
             />
             <div class="flex-grow">
-              <span class="text-lg font-medium text-gray-200">Remote Signer (NIP-46)</span>
-              <p class="text-sm text-gray-400 mt-1">Connect to nsec.app, nsecBunker, or other remote signers</p>
+              <span class="text-lg font-medium text-gray-400">Remote Signer (NIP-46)</span>
+              <p class="text-sm text-gray-500 mt-1">Connect to nsec.app, nsecBunker, or other remote signers</p>
               <div class="flex flex-wrap gap-2 mt-2">
-                <span class="text-xs bg-purple-900 text-purple-300 px-2 py-1 rounded">📱 Mobile friendly</span>
-                <span class="text-xs bg-yellow-900 text-yellow-300 px-2 py-1 rounded">🔒 Enhanced security</span>
+                <span class="text-xs bg-gray-800 text-gray-500 px-2 py-1 rounded">🚧 Coming Soon</span>
+                <span class="text-xs bg-purple-900 text-purple-400 px-2 py-1 rounded opacity-60">📱 Mobile friendly</span>
+                <span class="text-xs bg-yellow-900 text-yellow-400 px-2 py-1 rounded opacity-60">🔒 Enhanced security</span>
               </div>
             </div>
           </label>

--- a/src/App.vue
+++ b/src/App.vue
@@ -195,16 +195,97 @@
     </header>
 
     <main class="container mx-auto px-4 py-8 flex-grow">
-      <div v-if="!isConnected" class="card max-w-xl mx-auto my-12 text-center">
-        <h2 class="text-2xl mb-6">Connect to start hunting zombies!</h2>
-        <p class="mb-8">Connect your Nostr extension to manage your dormant follows and clean up your follow list.</p>
-        <button @click="connectNostr" class="btn-primary text-lg">Connect to Nostr</button>
+      <div v-if="!isConnected" class="card max-w-2xl mx-auto my-12">
+        <div class="text-center mb-8">
+          <div class="text-6xl mb-6">🧟‍♂️</div>
+          <h2 class="text-3xl mb-4">Connect to start hunting zombies!</h2>
+          <p class="text-gray-300">Choose your signing method to connect and manage your dormant follows.</p>
+        </div>
+        
+        <!-- Signing Method Selection -->
+        <div class="space-y-4 mb-8">
+          <h3 class="text-lg text-gray-300 mb-4 text-center">How would you like to connect?</h3>
+          
+          <label class="flex items-start gap-4 p-4 border border-gray-700 rounded-lg cursor-pointer hover:bg-gray-800 transition-colors">
+            <input 
+              type="radio" 
+              value="nip07" 
+              v-model="loginSigningMethod" 
+              class="w-5 h-5 text-zombie-green focus:ring-zombie-green mt-0.5"
+            />
+            <div class="flex-grow">
+              <span class="text-lg font-medium text-gray-200">Browser Extension (NIP-07)</span>
+              <p class="text-sm text-gray-400 mt-1">Use Alby, nos2x, or other browser extensions</p>
+              <div class="flex flex-wrap gap-2 mt-2">
+                <span class="text-xs bg-green-900 text-green-300 px-2 py-1 rounded">✅ Easy setup</span>
+                <span class="text-xs bg-blue-900 text-blue-300 px-2 py-1 rounded">⚡ Fast signing</span>
+              </div>
+            </div>
+          </label>
+          
+          <label class="flex items-start gap-4 p-4 border border-gray-700 rounded-lg cursor-pointer hover:bg-gray-800 transition-colors">
+            <input 
+              type="radio" 
+              value="nip46" 
+              v-model="loginSigningMethod" 
+              class="w-5 h-5 text-zombie-green focus:ring-zombie-green mt-0.5"
+            />
+            <div class="flex-grow">
+              <span class="text-lg font-medium text-gray-200">Remote Signer (NIP-46)</span>
+              <p class="text-sm text-gray-400 mt-1">Connect to nsec.app, nsecBunker, or other remote signers</p>
+              <div class="flex flex-wrap gap-2 mt-2">
+                <span class="text-xs bg-purple-900 text-purple-300 px-2 py-1 rounded">📱 Mobile friendly</span>
+                <span class="text-xs bg-yellow-900 text-yellow-300 px-2 py-1 rounded">🔒 Enhanced security</span>
+              </div>
+            </div>
+          </label>
+        </div>
+        
+        <div class="text-center">
+          <button @click="connectNostr" :disabled="!loginSigningMethod" class="btn-primary text-lg px-8 py-3">
+            {{ getConnectButtonText() }}
+          </button>
+          
+          <p class="text-xs text-gray-500 mt-4">
+            You can change your signing method later in Settings
+          </p>
+        </div>
       </div>
 
       <div v-else>
         <component :is="currentView"></component>
       </div>
     </main>
+
+    <!-- NIP-46 Setup Modal -->
+    <div 
+      v-if="showNip46Setup" 
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4" 
+      @click="closeNip46Setup"
+    >
+      <div class="bg-zombie-dark border border-gray-700 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto" @click.stop>
+        <div class="p-6">
+          <div class="flex items-center justify-between mb-6">
+            <div>
+              <h2 class="text-2xl font-bold text-gray-100">Setup Remote Signer</h2>
+              <p class="text-gray-400 mt-1">Connect to your NIP-46 bunker to continue</p>
+            </div>
+            <button 
+              @click="closeNip46Setup"
+              class="text-gray-400 hover:text-gray-200 text-2xl leading-none"
+            >
+              ×
+            </button>
+          </div>
+          
+          <!-- Use the existing Nip46Connection component -->
+          <Nip46Connection 
+            @connected="onNip46Connected"
+            @disconnected="closeNip46Setup"
+          />
+        </div>
+      </div>
+    </div>
 
     <footer class="mt-auto py-6 bg-zombie-dark border-t border-gray-700">
       <div class="container mx-auto px-4 text-center text-gray-400">
@@ -222,6 +303,7 @@ import BackupsView from './views/BackupsView.vue';
 import SettingsView from './views/SettingsView.vue';
 import FollowsManagerView from './views/FollowsManagerView.vue';
 import CopyButton from './components/CopyButton.vue';
+import Nip46Connection from './components/Nip46Connection.vue';
 import nostrService from './services/nostrService';
 import backupService from './services/backupService';
 import immunityService from './services/immunityService';
@@ -235,7 +317,8 @@ export default {
     BackupsView,
     SettingsView,
     FollowsManagerView,
-    CopyButton
+    CopyButton,
+    Nip46Connection
   },
   data() {
     return {
@@ -244,6 +327,8 @@ export default {
       mobileMenuOpen: false,
       userDropdownOpen: false,
       userProfile: null,
+      loginSigningMethod: 'nip07', // Default to NIP-07 for login
+      showNip46Setup: false, // Show NIP-46 setup modal
       views: {
         dashboard: markRaw(DashboardView),
         hunting: markRaw(ZombieHuntingView),
@@ -267,20 +352,33 @@ export default {
     },
     async connectNostr() {
       try {
-        console.log('🚀 Starting Nostr connection...');
+        console.log(`🚀 Starting Nostr connection with ${this.loginSigningMethod}...`);
         
-        // Use the new proper connection flow
-        const connectionResult = await nostrService.connectExtension();
-        console.log('✅ Extension connected successfully:', connectionResult);
+        // Only set the signing method if it's different to avoid resetting NDK
+        if (nostrService.getSigningMethod() !== this.loginSigningMethod) {
+          nostrService.setSigningMethod(this.loginSigningMethod);
+        }
         
-        this.isConnected = true;
-        this.userProfile = nostrService.userProfile;
-        
-        // Initialize other services (NDK is already initialized by connectExtension)
-        backupService.init();
-        await immunityService.init();
-        
-        console.log('🎉 Successfully connected to Nostr with', connectionResult.extensionType);
+        if (this.loginSigningMethod === 'nip07') {
+          // Use NIP-07 connection flow
+          const connectionResult = await nostrService.connectExtension();
+          console.log('✅ Extension connected successfully:', connectionResult);
+          
+          this.isConnected = true;
+          this.userProfile = nostrService.userProfile;
+          
+          // Initialize other services (NDK is already initialized by connectExtension)
+          backupService.init();
+          await immunityService.init();
+          
+          console.log('🎉 Successfully connected to Nostr with', connectionResult.extensionType);
+          
+        } else if (this.loginSigningMethod === 'nip46') {
+          // For NIP-46, show the setup modal
+          console.log('📱 Opening NIP-46 setup modal...');
+          this.showNip46Setup = true;
+          return; // Don't mark as connected yet
+        }
         
       } catch (error) {
         console.error('❌ Failed to connect to Nostr:', error);
@@ -297,6 +395,18 @@ export default {
         
         alert(`Failed to connect to Nostr:\n\n${userMessage}\n\nIf you continue having issues, try disconnecting and reconnecting this site in your Nostr extension settings.`);
       }
+    },
+    
+    getConnectButtonText() {
+      if (!this.loginSigningMethod) return 'Select a method';
+      
+      if (this.loginSigningMethod === 'nip07') {
+        return 'Connect Browser Extension';
+      } else if (this.loginSigningMethod === 'nip46') {
+        return 'Setup Remote Signer';
+      }
+      
+      return 'Connect to Nostr';
     },
     
     logout() {
@@ -320,24 +430,51 @@ export default {
     
     handleAvatarError(event) {
       event.target.src = '/default-avatar.svg';
+    },
+    
+    onNip46Connected(event) {
+      console.log('✅ NIP-46 connected from setup modal:', event.detail);
+      this.isConnected = true;
+      this.userProfile = {
+        pubkey: event.detail.pubkey,
+        // NIP-46 doesn't provide profile initially, will be loaded later
+        display_name: event.detail.pubkey.substring(0, 8) + '...',
+        name: 'NIP-46 User'
+      };
+      
+      // Initialize other services
+      backupService.init();
+      immunityService.init();
+      
+      // Close the setup modal and navigate to dashboard
+      this.showNip46Setup = false;
+      this.activeView = 'dashboard';
+    },
+    
+    closeNip46Setup() {
+      this.showNip46Setup = false;
+      this.loginSigningMethod = 'nip07'; // Reset to default
     }
   },
   async mounted() {
     // Try to restore session from localStorage
     const sessionRestored = await nostrService.restoreSession();
-    if (sessionRestored && nostrService.isExtensionReady()) {
+    if (sessionRestored && (nostrService.isExtensionReady() || nostrService.isBunkerReady())) {
       this.isConnected = true;
       this.userProfile = nostrService.userProfile;
       console.log('✅ Session restored successfully');
     } else if (sessionRestored) {
-      // Session data exists but extension not ready - clear it
-      console.log('⚠️ Session data found but extension not ready - clearing session');
+      // Session data exists but no signing method ready - clear it
+      console.log('⚠️ Session data found but no signing method ready - clearing session');
       nostrService.logout();
     }
     
     // Initialize services
     backupService.init();
     immunityService.init();
+    
+    // Listen for NIP-46 connection events from SettingsView
+    window.addEventListener('nip46-connected', this.onNip46Connected);
     
     // Close menus when clicking outside
     document.addEventListener('click', (e) => {
@@ -348,6 +485,10 @@ export default {
         this.userDropdownOpen = false;
       }
     });
+  },
+  
+  beforeUnmount() {
+    window.removeEventListener('nip46-connected', this.onNip46Connected);
   }
 }
 </script>

--- a/src/components/Nip46Connection.vue
+++ b/src/components/Nip46Connection.vue
@@ -1,0 +1,259 @@
+<template>
+  <div class="card">
+    <div class="flex items-center justify-between mb-4">
+      <h3 class="text-xl font-semibold text-gray-100">Remote Signer (NIP-46)</h3>
+      <div v-if="connectionStatus.connected" class="flex items-center gap-2">
+        <span class="w-2 h-2 bg-zombie-green rounded-full"></span>
+        <span class="text-sm text-zombie-green">Connected</span>
+      </div>
+    </div>
+
+    <!-- Connection Status -->
+    <div v-if="connectionStatus.connected" class="mb-6">
+      <div class="bg-gray-900 rounded-lg p-4 space-y-2">
+        <div class="flex justify-between items-center">
+          <span class="text-gray-300">Status:</span>
+          <span class="text-zombie-green font-medium">✅ Connected to bunker</span>
+        </div>
+        <div class="flex justify-between items-center">
+          <span class="text-gray-300">Bunker:</span>
+          <span class="text-gray-100 font-mono text-sm">
+            {{ connectionStatus.bunkerPubkey?.substring(0, 8) }}...
+          </span>
+        </div>
+        <div class="flex justify-between items-center">
+          <span class="text-gray-300">Relay:</span>
+          <span class="text-gray-100 text-sm">
+            {{ connectionStatus.bunkerRelays?.[0] }}
+          </span>
+        </div>
+      </div>
+      
+      <div class="mt-4 flex justify-between items-center">
+        <p class="text-gray-400 text-sm">
+          Your bunker will handle all signing requests
+        </p>
+        <button 
+          @click="disconnect"
+          :disabled="disconnecting"
+          class="btn-secondary text-sm"
+        >
+          {{ disconnecting ? 'Disconnecting...' : 'Disconnect' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Connection Form -->
+    <div v-else class="space-y-4">
+      <div v-if="connecting" class="bg-blue-900 rounded-lg p-4 text-center">
+        <div class="flex items-center justify-center gap-2">
+          <div class="animate-spin w-4 h-4 border-2 border-blue-400 border-t-transparent rounded-full"></div>
+          <span class="text-blue-400">Connecting to bunker...</span>
+        </div>
+        <p class="text-sm text-gray-300 mt-2">This may take a few seconds</p>
+      </div>
+
+      <div class="space-y-3">
+        <div class="space-y-2">
+          <label class="block text-sm font-medium text-gray-300">
+            Bunker URL
+          </label>
+          <div class="relative">
+            <input 
+              v-model="bunkerUrl" 
+              type="text"
+              placeholder="bunker://..."
+              class="input w-full pr-10"
+              @paste="handleUrlPaste"
+              :disabled="connecting"
+            />
+            <button
+              v-if="bunkerUrl"
+              @click="bunkerUrl = ''"
+              class="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-200"
+            >
+              ✕
+            </button>
+          </div>
+          <p class="text-xs text-gray-500">
+            Copy a bunker URL from your remote signer app
+          </p>
+        </div>
+
+        <button 
+          @click="connect"
+          :disabled="connecting || !bunkerUrl.trim()"
+          class="btn-primary w-full"
+        >
+          {{ connecting ? 'Connecting...' : 'Connect to Bunker' }}
+        </button>
+      </div>
+
+      <!-- Error Display -->
+      <div v-if="error" class="bg-red-900 border border-red-700 rounded-lg p-3">
+        <div class="flex items-start gap-2">
+          <span class="text-red-400 mt-0.5">⚠️</span>
+          <div class="flex-1">
+            <p class="text-red-400 text-sm font-medium">Connection Failed</p>
+            <p class="text-red-300 text-xs mt-1">{{ error }}</p>
+          </div>
+          <button 
+            @click="error = null"
+            class="text-red-400 hover:text-red-300"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <!-- Help Section -->
+      <div class="bg-gray-900 rounded-lg p-4">
+        <h4 class="text-sm font-medium text-gray-200 mb-2">
+          🔗 Get a Bunker URL
+        </h4>
+        <p class="text-xs text-gray-400 mb-3">
+          You need a remote signer (bunker) to provide the connection URL. Popular options:
+        </p>
+        <div class="space-y-2">
+          <a 
+            href="https://nsec.app" 
+            target="_blank"
+            class="flex items-center gap-2 text-xs px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded transition-colors"
+          >
+            <span class="w-2 h-2 bg-blue-400 rounded-full"></span>
+            nsec.app - Web-based bunker service
+            <span class="ml-auto">↗</span>
+          </a>
+          <a 
+            href="https://nsecbunker.com" 
+            target="_blank"
+            class="flex items-center gap-2 text-xs px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded transition-colors"
+          >
+            <span class="w-2 h-2 bg-green-400 rounded-full"></span>
+            nsecBunker - Self-hosted option
+            <span class="ml-auto">↗</span>
+          </a>
+        </div>
+        <div class="mt-3 p-2 bg-gray-800 rounded text-xs">
+          <p class="text-gray-400">
+            <strong class="text-gray-300">How it works:</strong> Your private keys stay in the bunker app. 
+            When Plebs vs Zombies needs to sign events, it sends requests to your bunker for approval.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import nostrService from '../services/nostrService';
+
+export default {
+  name: 'Nip46Connection',
+  data() {
+    return {
+      bunkerUrl: '',
+      connecting: false,
+      disconnecting: false,
+      error: null,
+      connectionStatus: {
+        connected: false,
+        connecting: false,
+        bunkerPubkey: null,
+        bunkerRelays: [],
+        hasLocalKey: false
+      }
+    };
+  },
+  mounted() {
+    this.updateConnectionStatus();
+  },
+  methods: {
+    updateConnectionStatus() {
+      this.connectionStatus = nostrService.nip46Service.getConnectionStatus();
+    },
+
+    async connect() {
+      if (!this.bunkerUrl.trim()) {
+        this.error = 'Please enter a bunker URL';
+        return;
+      }
+
+      this.connecting = true;
+      this.error = null;
+
+      try {
+        console.log('🔌 Attempting to connect to bunker...');
+        const result = await nostrService.nip46Service.connectWithBunkerUrl(this.bunkerUrl.trim());
+        
+        console.log('✅ Bunker connection successful:', result);
+        
+        // Switch nostrService to NIP-46 mode
+        nostrService.setSigningMethod('nip46');
+        
+        // Update connection status
+        this.updateConnectionStatus();
+        
+        // Clear the URL input
+        this.bunkerUrl = '';
+        
+        this.$emit('connected', result);
+        
+      } catch (error) {
+        console.error('❌ Bunker connection failed:', error);
+        this.error = error.message;
+      } finally {
+        this.connecting = false;
+      }
+    },
+
+    async disconnect() {
+      this.disconnecting = true;
+      
+      try {
+        await nostrService.nip46Service.disconnect();
+        
+        // Switch back to NIP-07 mode
+        nostrService.setSigningMethod('nip07');
+        
+        // Update connection status
+        this.updateConnectionStatus();
+        
+        this.$emit('disconnected');
+        
+      } catch (error) {
+        console.error('❌ Disconnect failed:', error);
+        this.error = 'Failed to disconnect: ' + error.message;
+      } finally {
+        this.disconnecting = false;
+      }
+    },
+
+    handleUrlPaste(event) {
+      // Handle paste event - could add validation here
+      setTimeout(() => {
+        if (this.bunkerUrl && !this.bunkerUrl.startsWith('bunker://')) {
+          this.error = 'Invalid bunker URL format. Must start with bunker://';
+        } else {
+          this.error = null;
+        }
+      }, 100);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.animate-spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/services/nip46Service.js
+++ b/src/services/nip46Service.js
@@ -1,0 +1,311 @@
+import NDK, { NDKNip46Signer } from '@nostr-dev-kit/ndk';
+
+class Nip46Service {
+  constructor() {
+    this.signer = null;
+    this.connected = false;
+    this.connecting = false;
+    this.bunkerPubkey = null;
+    this.bunkerRelays = [];
+    this.localPrivateKey = null;
+    this.connectionSecret = null;
+    this.appName = 'Plebs vs Zombies';
+  }
+
+  /**
+   * Parse a bunker URL and extract connection details
+   * Format: bunker://pubkey?relay=wss://relay.com&secret=xxx&name=AppName
+   */
+  parseBunkerUrl(bunkerUrl) {
+    try {
+      if (!bunkerUrl.startsWith('bunker://')) {
+        throw new Error('Invalid bunker URL format. Must start with bunker://');
+      }
+
+      const url = new URL(bunkerUrl);
+      const pubkey = url.hostname;
+      const relay = url.searchParams.get('relay');
+      const secret = url.searchParams.get('secret');
+      const name = url.searchParams.get('name');
+
+      if (!pubkey || pubkey.length !== 64) {
+        throw new Error('Invalid pubkey in bunker URL');
+      }
+
+      if (!relay || !relay.startsWith('wss://')) {
+        throw new Error('Invalid or missing relay in bunker URL');
+      }
+
+      return {
+        pubkey,
+        relay,
+        secret,
+        name: name || this.appName
+      };
+    } catch (error) {
+      console.error('Failed to parse bunker URL:', error);
+      throw new Error(`Invalid bunker URL: ${error.message}`);
+    }
+  }
+
+  /**
+   * Connect using a bunker URL
+   */
+  async connectWithBunkerUrl(bunkerUrl, localPrivateKey = null) {
+    if (this.connecting) {
+      throw new Error('Connection already in progress');
+    }
+
+    this.connecting = true;
+
+    try {
+      console.log('🔌 Connecting to NIP-46 bunker...');
+      
+      const bunkerDetails = this.parseBunkerUrl(bunkerUrl);
+      
+      // Generate local private key if not provided (for client-side session)
+      if (!localPrivateKey) {
+        const { generateSecretKey } = await import('nostr-tools/pure');
+        localPrivateKey = generateSecretKey();
+      }
+
+      this.localPrivateKey = localPrivateKey;
+      this.bunkerPubkey = bunkerDetails.pubkey;
+      this.bunkerRelays = [bunkerDetails.relay];
+      this.connectionSecret = bunkerDetails.secret;
+
+      // Create NDK instance for bunker communication
+      const bunkerNdk = new NDK({
+        explicitRelayUrls: this.bunkerRelays
+      });
+
+      await bunkerNdk.connect();
+      console.log('✅ Connected to bunker relays');
+
+      // Create NIP-46 signer
+      this.signer = new NDKNip46Signer(
+        bunkerNdk,
+        this.bunkerPubkey,
+        localPrivateKey
+      );
+
+      // Test connection by getting public key
+      console.log('🔐 Testing bunker connection...');
+      const testPubkey = await this.signer.user().then(user => user.pubkey);
+      
+      if (!testPubkey) {
+        throw new Error('Failed to get public key from bunker');
+      }
+
+      console.log('✅ NIP-46 connection established');
+      console.log('👤 Remote pubkey:', testPubkey.substring(0, 8) + '...');
+
+      this.connected = true;
+      this.connecting = false;
+
+      // Save connection details for reconnection
+      this.saveConnectionDetails({
+        bunkerPubkey: this.bunkerPubkey,
+        bunkerRelays: this.bunkerRelays,
+        localPrivateKey: Array.from(this.localPrivateKey), // Convert Uint8Array to array for storage
+        connectionSecret: this.connectionSecret,
+        timestamp: Date.now()
+      });
+
+      return {
+        success: true,
+        pubkey: testPubkey,
+        bunkerPubkey: this.bunkerPubkey,
+        relay: bunkerDetails.relay
+      };
+
+    } catch (error) {
+      this.connecting = false;
+      this.connected = false;
+      console.error('❌ NIP-46 connection failed:', error);
+      throw new Error(`Failed to connect to bunker: ${error.message}`);
+    }
+  }
+
+  /**
+   * Connect with manual details
+   */
+  async connectWithDetails(pubkey, relays, secret, localPrivateKey = null) {
+    const bunkerUrl = `bunker://${pubkey}?relay=${relays[0]}&secret=${secret}&name=${encodeURIComponent(this.appName)}`;
+    return await this.connectWithBunkerUrl(bunkerUrl, localPrivateKey);
+  }
+
+  /**
+   * Restore connection from saved details
+   */
+  async restoreConnection() {
+    try {
+      const savedConnection = this.getSavedConnectionDetails();
+      
+      if (!savedConnection) {
+        console.log('ℹ️ No saved NIP-46 connection found');
+        return false;
+      }
+
+      // Check if connection is not too old (7 days)
+      const maxAge = 7 * 24 * 60 * 60 * 1000;
+      if (Date.now() - savedConnection.timestamp > maxAge) {
+        console.log('⚠️ Saved NIP-46 connection expired');
+        this.clearSavedConnection();
+        return false;
+      }
+
+      console.log('🔄 Restoring NIP-46 connection...');
+      
+      // Convert array back to Uint8Array
+      const localPrivateKey = new Uint8Array(savedConnection.localPrivateKey);
+      
+      // Reconstruct bunker URL
+      const bunkerUrl = `bunker://${savedConnection.bunkerPubkey}?relay=${savedConnection.bunkerRelays[0]}&secret=${savedConnection.connectionSecret}&name=${encodeURIComponent(this.appName)}`;
+      
+      await this.connectWithBunkerUrl(bunkerUrl, localPrivateKey);
+      console.log('✅ NIP-46 connection restored');
+      return true;
+
+    } catch (error) {
+      console.warn('⚠️ Failed to restore NIP-46 connection:', error.message);
+      this.clearSavedConnection();
+      return false;
+    }
+  }
+
+  /**
+   * Disconnect from bunker
+   */
+  async disconnect() {
+    try {
+      if (this.signer && this.signer.ndk) {
+        await this.signer.ndk.pool.close();
+      }
+    } catch (error) {
+      console.warn('Error during NIP-46 disconnect:', error);
+    }
+
+    this.signer = null;
+    this.connected = false;
+    this.connecting = false;
+    this.bunkerPubkey = null;
+    this.bunkerRelays = [];
+    this.localPrivateKey = null;
+    this.connectionSecret = null;
+
+    // Clear saved connection
+    this.clearSavedConnection();
+    
+    console.log('✅ NIP-46 disconnected');
+  }
+
+  /**
+   * Check if connected and ready
+   */
+  isConnected() {
+    return this.connected && this.signer && !this.connecting;
+  }
+
+  /**
+   * Get connection status
+   */
+  getConnectionStatus() {
+    return {
+      connected: this.connected,
+      connecting: this.connecting,
+      bunkerPubkey: this.bunkerPubkey,
+      bunkerRelays: this.bunkerRelays,
+      hasLocalKey: !!this.localPrivateKey
+    };
+  }
+
+  /**
+   * Sign an event using the bunker
+   */
+  async signEvent(event) {
+    if (!this.isConnected()) {
+      throw new Error('NIP-46 bunker not connected');
+    }
+
+    try {
+      console.log('🔐 Requesting signature from bunker...');
+      const signedEvent = await this.signer.signEvent(event);
+      console.log('✅ Event signed by bunker');
+      return signedEvent;
+    } catch (error) {
+      console.error('❌ Bunker signing failed:', error);
+      
+      if (error.message.includes('user rejected')) {
+        throw new Error('Signing was rejected in the bunker app');
+      } else if (error.message.includes('timeout')) {
+        throw new Error('Signing request timed out. Please check your bunker app.');
+      } else {
+        throw new Error(`Bunker signing failed: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Get the remote user's public key
+   */
+  async getPublicKey() {
+    if (!this.isConnected()) {
+      throw new Error('NIP-46 bunker not connected');
+    }
+
+    try {
+      const user = await this.signer.user();
+      return user.pubkey;
+    } catch (error) {
+      console.error('Failed to get public key from bunker:', error);
+      throw new Error('Failed to get public key from bunker');
+    }
+  }
+
+  /**
+   * Save connection details to localStorage
+   */
+  saveConnectionDetails(details) {
+    try {
+      localStorage.setItem('nip46_connection', JSON.stringify(details));
+    } catch (error) {
+      console.warn('Failed to save NIP-46 connection details:', error);
+    }
+  }
+
+  /**
+   * Get saved connection details from localStorage
+   */
+  getSavedConnectionDetails() {
+    try {
+      const saved = localStorage.getItem('nip46_connection');
+      return saved ? JSON.parse(saved) : null;
+    } catch (error) {
+      console.warn('Failed to load NIP-46 connection details:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Clear saved connection details
+   */
+  clearSavedConnection() {
+    try {
+      localStorage.removeItem('nip46_connection');
+    } catch (error) {
+      console.warn('Failed to clear NIP-46 connection details:', error);
+    }
+  }
+
+  /**
+   * Get the NDK signer instance (for integration with NDK)
+   */
+  getSigner() {
+    return this.signer;
+  }
+}
+
+// Create singleton instance
+const nip46Service = new Nip46Service();
+export default nip46Service;


### PR DESCRIPTION
  Fix follow list to preserve t tags when unfollowing users

  Users want to keep their t tags (topic follows) when cleaning up their
  follow lists. The previous implementation was stripping all tags except
  p tags (user follows), causing topic subscriptions to be lost.

  Changes:
  - Modified createUnfollowEvent to preserve all non-p tags (including t tags)
  - Only removes specific p tags for users being unfollowed
  - Preserves original contact list content
  - Maintains topic subscriptions and other metadata