### PR TITLE
Scout Mode Menu Reset Fix

### DIFF
--- a/dev-notes.md
+++ b/dev-notes.md
@@ -1,0 +1,153 @@
+# Development Notes - Plebs vs. Zombies
+
+## Session: September 21, 2025
+
+### Branch: scout-post-fix
+Current status: Completed and ready for merge
+
+### Changes Made
+
+#### 1. Scout Mode UI Fixes
+**Problem**: Two UI bugs in Scout Mode were preventing smooth user experience
+
+**Fix 1: Social Post Modal Persistence** (`src/views/ScoutModeView.vue:828`)
+- **Issue**: After posting a scout report, clicking "Scout Different User" didn't hide the post modal, blocking view of new scan results
+- **Solution**: Added `this.showPostModal = false;` to `showScoutNewUser()` method
+- **Location**: Line 828 in ScoutModeView.vue
+
+**Fix 2: Start Scouting Button Stalling** (`src/views/ScoutModeView.vue:833-925`)
+- **Issue**: "Start Scouting" button in modal would sometimes hang/stall when trying to scout a new user
+- **Root Cause**: Async operations (service shutdown, reset, profile fetch) could hang without timeouts
+- **Solution**: 
+  - Added timeout handling to all async operations:
+    - Stop scan: 5 second timeout
+    - Service shutdown: 5 second timeout
+    - Service reset: 3 second timeout
+    - Profile fetch: 8 second timeout
+  - Added `processingNewUser` flag to prevent duplicate calls
+  - Added visual feedback: button shows "⏳ Processing..." when working
+  - Added extensive console logging for debugging
+  - Better error handling with specific timeout messages
+
+**Files Modified**:
+- `src/views/ScoutModeView.vue`
+  - Added `processingNewUser: false` to data (line 654)
+  - Updated `showScoutNewUser()` to reset modal state (line 828)
+  - Enhanced `scoutNewUser()` with timeout handling (lines 833-925)
+  - Updated modal button UI for processing state (lines 89-97)
+
+#### 2. Zombie Score Analytics Chart
+Created standalone visualization for Scout Mode data analysis
+
+**Files Created**:
+- `/charts/zombie-score-analysis-2025-09-14-to-20.html` - Interactive chart with zombie theme
+- `/charts/README-chart-creation.md` - Documentation for creating future charts
+
+**Chart Features**:
+- Fully self-contained HTML file (no external dependencies except Chart.js CDN)
+- Dark gradient background matching app theme
+- Interactive bar chart showing zombie score distribution
+- Color-coded bars: Green (low scores) → Red (high scores)
+- Zombie-themed styling with Creepster font and emojis (🧟‍♂️ 👁️ 🔍 🏹 💀)
+- Animated loading effects
+- Summary statistics cards
+- Timestamped throughout (filename, page title, headers, footer)
+
+**Chart Data (Sept 14-20, 2025)**:
+- Total scans: 40
+- Average zombie score: 22%
+- Range: 3.0% - 41.0%
+- Distribution:
+  - 3.0-6.8%: 2 plebs
+  - 6.8-10.6%: 5 plebs
+  - 10.6-14.4%: 2 plebs
+  - 14.4-18.2%: 7 plebs
+  - 18.2-22.0%: 1 pleb
+  - 22.0-25.8%: 9 plebs
+  - 25.8-29.6%: 7 plebs
+  - 29.6-33.4%: 3 plebs
+  - 33.4-37.2%: 3 plebs
+  - 37.2-41.0%: 1 pleb
+
+**GitHub Pages Setup**:
+- Enabled GitHub Pages for repo
+- Chart accessible at: https://dmnyc.github.io/plebs-vs-zombies/charts/zombie-score-analysis-2025-09-14-to-20.html
+- Auto-deploys on push to main branch
+
+**Chart Creation Process** (documented in `/charts/README-chart-creation.md`):
+1. Collect Scout Mode scan data over time period
+2. Calculate distribution across percentage ranges
+3. Copy chart template and update:
+   - Date ranges (filename, title, headers)
+   - Data arrays (labels and counts)
+   - Summary statistics
+4. Test locally then push to GitHub
+5. GitHub Pages auto-deploys
+
+### Commit Messages
+
+**Scout Mode Fixes** (on scout-post-fix branch):
+```
+Fix Scout Mode UI issues: modal persistence and button stalling
+
+- Fix social post modal not disappearing when clicking "Scout Different User"
+- Add timeout handling to prevent "Start Scouting" button from stalling
+- Add visual feedback and duplicate call prevention for new user scouting
+- Improve error handling with specific timeout messages
+
+Resolves issues where users couldn't see new scan results due to persistent 
+modals and unresponsive UI during user switching operations.
+```
+
+**Chart Creation** (on main branch):
+- Initial: "Created standalone Zombie Score Chart"
+- Update: "Update zombie-score-analysis-2025-09-14-to-20.html" (fixed average from 18.4% to 22%)
+
+### Next Steps
+
+1. **Merge scout-post-fix branch**:
+   ```bash
+   git checkout main
+   git merge scout-post-fix
+   git push origin main
+   ```
+
+2. **Optional: Clean up branch**:
+   ```bash
+   git branch -d scout-post-fix
+   git push origin --delete scout-post-fix
+   ```
+
+3. **Future Chart Updates**:
+   - Follow process in `/charts/README-chart-creation.md`
+   - Use existing chart as template
+   - Update date ranges and data
+   - Push to GitHub for auto-deployment
+
+### Technical Notes
+
+**Scout Mode Architecture**:
+- Main component: `src/views/ScoutModeView.vue`
+- Service layer: `src/services/scoutService.js`
+- Uses NDK for Nostr profile fetching
+- Implements aggressive retry logic for network operations
+
+**Known Considerations**:
+- Profile fetching can timeout (8 seconds) if relays are slow
+- Service shutdown/reset operations have 3-5 second timeouts
+- All timeouts are gracefully handled with error messages
+- Processing flag prevents concurrent scout operations
+
+**Dev Environment**:
+- Branch: scout-post-fix (ready for merge)
+- Multiple dev servers running (can be cleaned up with `killall node` if needed)
+- Git status: clean, all changes committed
+
+### Files to Review Before Merge
+- `src/views/ScoutModeView.vue` - Main Scout Mode component with UI fixes
+- `charts/zombie-score-analysis-2025-09-14-to-20.html` - Data visualization
+- `charts/README-chart-creation.md` - Chart creation documentation
+
+---
+*Session ended: Computer restart needed*
+*Resume: Merge scout-post-fix branch when ready*

--- a/src/App.vue
+++ b/src/App.vue
@@ -718,32 +718,7 @@ export default {
         }
       }
     },
-    async showScoutModeMenu() {
-      // If already in Scout Mode, reset the display to show new scout UI
-      if (this.isScoutMode) {
-        // Reset scout service state (similar to showScoutNewUser button)
-        await scoutService.forceShutdown();
-        await scoutService.reset();
-
-        // Reset the ScoutModeView component state
-        if (this.$refs.scoutModeComponent) {
-          // Reset component state similar to what showScoutNewUser does
-          this.$refs.scoutModeComponent.scoutComplete = false;
-          this.$refs.scoutModeComponent.scoutResults = null;
-          this.$refs.scoutModeComponent.posted = false;
-          this.$refs.scoutModeComponent.copied = false;
-          this.$refs.scoutModeComponent.isMyReport = false;
-          this.$refs.scoutModeComponent.showPostModal = false;
-          this.$refs.scoutModeComponent.expandedSections = {
-            active: false,
-            fresh: false,
-            rotting: false,
-            ancient: false,
-            burned: false
-          };
-        }
-      }
-
+    showScoutModeMenu() {
       // For signed-in users, show Scout Mode modal
       this.showScoutModal = true;
       this.scoutNpub = '';
@@ -754,10 +729,31 @@ export default {
       this.scoutNpub = '';
       this.scoutNpubError = '';
     },
-    startScoutFromModal() {
+    async startScoutFromModal() {
       if (this.scoutNpubValid) {
         this.showScoutModal = false;
-        this.startScoutMode();
+
+        // If already in Scout Mode, force a complete reset by exiting and re-entering
+        if (this.isScoutMode) {
+          console.log('🔄 Already in Scout Mode, doing complete reset...');
+
+          // Force shutdown and reset scout service
+          await scoutService.forceShutdown();
+          await scoutService.reset();
+
+          // Temporarily exit scout mode to force component remount
+          this.isScoutMode = false;
+          this.scoutTarget = null;
+
+          // Wait for Vue to process the state change
+          await this.$nextTick();
+
+          // Now start scout mode with new target
+          await this.startScoutMode();
+        } else {
+          // Not in Scout Mode yet, start normally
+          await this.startScoutMode();
+        }
       }
     },
     async startScoutMode() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -253,8 +253,9 @@
     <main class="container mx-auto px-4 py-8 flex-grow">
       <!-- Scout Mode View -->
       <div v-if="isScoutMode">
-        <ScoutModeView 
-          :scout-target="scoutTarget" 
+        <ScoutModeView
+          ref="scoutModeComponent"
+          :scout-target="scoutTarget"
           :is-logged-in="isConnected"
           @update-target="updateScoutTarget"
           @exit-scout="exitScoutMode"
@@ -717,7 +718,32 @@ export default {
         }
       }
     },
-    showScoutModeMenu() {
+    async showScoutModeMenu() {
+      // If already in Scout Mode, reset the display to show new scout UI
+      if (this.isScoutMode) {
+        // Reset scout service state (similar to showScoutNewUser button)
+        await scoutService.forceShutdown();
+        await scoutService.reset();
+
+        // Reset the ScoutModeView component state
+        if (this.$refs.scoutModeComponent) {
+          // Reset component state similar to what showScoutNewUser does
+          this.$refs.scoutModeComponent.scoutComplete = false;
+          this.$refs.scoutModeComponent.scoutResults = null;
+          this.$refs.scoutModeComponent.posted = false;
+          this.$refs.scoutModeComponent.copied = false;
+          this.$refs.scoutModeComponent.isMyReport = false;
+          this.$refs.scoutModeComponent.showPostModal = false;
+          this.$refs.scoutModeComponent.expandedSections = {
+            active: false,
+            fresh: false,
+            rotting: false,
+            ancient: false,
+            burned: false
+          };
+        }
+      }
+
       // For signed-in users, show Scout Mode modal
       this.showScoutModal = true;
       this.scoutNpub = '';

--- a/src/views/ScoutModeView.vue
+++ b/src/views/ScoutModeView.vue
@@ -351,13 +351,17 @@
             📢 Share Scout Report
           </h4>
           
-          <!-- "This is me!" toggle -->
-          <div class="mb-3">
+          <!-- "This is me!" toggle with prominent callout -->
+          <div class="mb-4 p-3 bg-yellow-900/20 border border-yellow-600/30 rounded-lg">
+            <div class="text-yellow-400 text-sm font-medium mb-2">
+              Sharing your own Zombie Score? Check this box!
+            </div>
             <label class="inline-flex items-center gap-2 cursor-pointer">
-              <input 
-                type="checkbox" 
+              <div class="text-yellow-400 text-lg">👉</div>
+              <input
+                type="checkbox"
                 v-model="isMyReport"
-                class="w-4 h-4 text-purple-600 bg-gray-700 border-gray-600 rounded focus:ring-purple-500 focus:ring-2"
+                class="w-4 h-4 text-yellow-600 bg-gray-700 border-gray-600 rounded focus:ring-yellow-500 focus:ring-2"
               >
               <span class="text-sm text-gray-300">This is me!</span>
             </label>
@@ -834,9 +838,12 @@ https://plebs-vs-zombies.vercel.app`;
     },
     async scoutNewUser() {
       if (!this.newScoutValid) return;
-      
+
       // Prevent multiple simultaneous calls
-      if (this.processingNewUser) return;
+      if (this.processingNewUser) {
+        console.log('⚠️ scoutNewUser already processing, ignoring duplicate call');
+        return;
+      }
       this.processingNewUser = true;
       
       try {


### PR DESCRIPTION
  Scout Mode Menu Reset Fix:
  - When clicking "Scout Mode" menu item while already in Scout Mode, now properly
    resets display and auto-starts new scout instead of showing stale results
  - Uses complete reset approach: shutdown service, temporarily exit Scout Mode,
    then re-enter with new target to force component remount
  - Eliminates race conditions and timing issues with component refs
  - Provides reliable first-try functionality

  Social Post UX Enhancement:
  - Added prominent yellow callout box around "This is me!" checkbox
  - Included pointing finger emoji (👉) and clear instruction text:
    "Sharing your own Zombie Score? Check this box!"
  - Makes it obvious when users should check the box for personal vs scouting posts
  - Improved visual hierarchy with yellow theming throughout