### PR TITLE
Fix: Hunt Now button navigation and responsive menu breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plebs-vs-zombies",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A Nostr utility for managing dormant follows",
   "main": "index.js",
   "type": "module",

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@
           
           <div class="flex items-center">
             <!-- Desktop Navigation for signed-in users -->
-            <nav v-if="isConnected" class="hidden lg:block">
+            <nav v-if="isConnected" class="hidden xl:block">
               <ul class="flex gap-6">
                 <li>
                   <a 
@@ -86,7 +86,7 @@
             </nav>
             
             <!-- Desktop Navigation for signed-out Scout Mode -->
-            <nav v-if="!isConnected && isScoutMode" class="hidden lg:block">
+            <nav v-if="!isConnected && isScoutMode" class="hidden xl:block">
               <ul class="flex gap-6">
                 <li>
                   <a 
@@ -104,9 +104,9 @@
             <div class="flex items-center ml-auto">
               <!-- User Avatar and Dropdown -->  
               <div v-if="isConnected && userProfile" class="relative">
-                <button 
+                <button
                   @click="userDropdownOpen = !userDropdownOpen"
-                  class="hover:bg-gray-800 rounded-lg transition-colors lg:ml-4"
+                  class="hover:bg-gray-800 rounded-lg transition-colors xl:ml-4"
                 >
                   <img 
                     :src="userProfile?.picture || '/default-avatar.svg'" 
@@ -140,10 +140,10 @@
               </div>
               
               <!-- Mobile/Tablet Hamburger Button -->
-              <button 
+              <button
                 v-if="isConnected"
                 @click="mobileMenuOpen = !mobileMenuOpen"
-                class="lg:hidden flex flex-col justify-center items-center w-8 h-8 border border-gray-600 rounded-lg hover:bg-gray-800 transition-colors ml-2"
+                class="xl:hidden flex flex-col justify-center items-center w-8 h-8 border border-gray-600 rounded-lg hover:bg-gray-800 transition-colors ml-2"
                 :class="{'bg-gray-800': mobileMenuOpen}"
               >
                 <span class="w-5 h-0.5 bg-white transition-all" :class="mobileMenuOpen ? 'rotate-45 translate-y-1' : ''"></span>
@@ -155,7 +155,7 @@
         </div>
         
         <!-- Mobile/Tablet Navigation Menu -->
-        <nav v-if="isConnected && mobileMenuOpen" class="lg:hidden mt-4 pt-4 border-t border-gray-700">
+        <nav v-if="isConnected && mobileMenuOpen" class="xl:hidden mt-4 pt-4 border-t border-gray-700">
           <!-- User Info Section (Mobile) -->
           <div v-if="isConnected && userProfile" class="mb-4 p-3 bg-gray-800 rounded-lg">
             <div class="flex items-center gap-3 mb-3">

--- a/src/views/BackupsView.vue
+++ b/src/views/BackupsView.vue
@@ -192,25 +192,17 @@ export default {
   },
   methods: {
     goToZombieHunting() {
-      this.$emit('navigate', 'hunting');
-      // If the parent App doesn't handle navigate event, use router or direct method
-      if (this.$parent && this.$parent.setActiveView) {
-        this.$parent.setActiveView('hunting');
-      }
+      this.$router.push('/hunt');
     },
     goToRelayBackups() {
-      this.$emit('navigate', 'settings');
-      // If the parent App doesn't handle navigate event, use router or direct method
-      if (this.$parent && this.$parent.setActiveView) {
-        this.$parent.setActiveView('settings');
-        // Scroll to relay backup section after navigation
-        this.$nextTick(() => {
-          const element = document.getElementById('relay-backup');
-          if (element) {
-            element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          }
-        });
-      }
+      this.$router.push('/settings');
+      // Scroll to relay backup section after navigation
+      this.$nextTick(() => {
+        const element = document.getElementById('relay-backup');
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
     },
     async copyRelay() {
       try {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -572,10 +572,10 @@ export default {
       }
     },
     goToZombieHunting() {
-      this.$parent.setActiveView('hunting');
+      this.$router.push('/hunt');
     },
     goToBackups() {
-      this.$parent.setActiveView('backups');
+      this.$router.push('/backups');
     },
     async resetImmunity() {
       const count = this.followStats.immune;
@@ -644,7 +644,7 @@ export default {
     handleGoToBackups() {
       localStorage.setItem('pvz-welcome-seen', 'true');
       this.showWelcomeModal = false;
-      this.$parent.setActiveView('backups');
+      this.$router.push('/backups');
     },
     handleSkipBackup() {
       this.showWelcomeModal = false;

--- a/src/views/FollowsManagerView.vue
+++ b/src/views/FollowsManagerView.vue
@@ -586,11 +586,7 @@ export default {
       }
     },
     goToZombieHunting() {
-      this.$emit('navigate', 'hunting');
-      // If the parent App doesn't handle navigate event, use router or direct method
-      if (this.$parent && this.$parent.setActiveView) {
-        this.$parent.setActiveView('hunting');
-      }
+      this.$router.push('/hunt');
     },
     handleAvatarError(event) {
       const img = event.target;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -824,11 +824,7 @@ export default {
   },
   methods: {
     goToZombieHunting() {
-      this.$emit('navigate', 'hunting');
-      // If the parent App doesn't handle navigate event, use router or direct method
-      if (this.$parent && this.$parent.setActiveView) {
-        this.$parent.setActiveView('hunting');
-      }
+      this.$router.push('/hunt');
     },
 
     updateConnectionStatus() {

--- a/src/views/ZombieHuntingView.vue
+++ b/src/views/ZombieHuntingView.vue
@@ -1017,7 +1017,7 @@ export default {
           
           if (shouldContinue) {
             // Navigate to backups page
-            this.$parent.setActiveView('backups');
+            this.$router.push('/backups');
             return false;
           }
           
@@ -1045,8 +1045,8 @@ export default {
           );
           
           if (shouldContinue) {
-            // Navigate to backups page  
-            this.$parent.setActiveView('backups');
+            // Navigate to backups page
+            this.$router.push('/backups');
             return false;
           }
         }


### PR DESCRIPTION
- Fixed all Hunt Zombies buttons not working (changed from this.$parent.setActiveView to this.$router.push)
- Updated navigation breakpoint from lg (1024px) to xl (1280px) to prevent text wrapping on tablet-sized screens
- Hamburger menu now appears on more screen sizes for better mobile/tablet UX

Fixes:
- Dashboard "Start Hunting Now" button
- Dashboard "Start Zombie Hunt" button
- Backups "Hunt Zombies Safely" button
- Follows "Hunt Zombies" CTA
- Settings "Hunt Zombies" button
- ZombieHunting backup warning navigation

Version: 0.6.2