### PR TITLE
v0.8.1: Fix scan accuracy, smart relay retry, and date range filter

### DIFF
--- a/src/services/nostrService.js
+++ b/src/services/nostrService.js
@@ -1001,8 +1001,9 @@ class NostrService {
       `🔍 Starting balanced activity scan for ${pubkeys.length} profiles...`,
     );
 
-    // Balanced approach: reasonable batches, good event coverage, sufficient time window
-    const batchSize = 25; // Balanced batch size
+    // Smaller batches ensure each user gets relay coverage
+    // Larger batches cause prolific posters to crowd out quieter users in results
+    const batchSize = 10;
     const totalBatches = Math.ceil(pubkeys.length / batchSize);
 
     for (let i = 0; i < pubkeys.length; i += batchSize) {
@@ -1010,12 +1011,14 @@ class NostrService {
       const batchNum = Math.floor(i / batchSize) + 1;
 
       try {
-        // Comprehensive filter - multiple event types, reasonable time window
+        // Comprehensive filter - multiple event types, full year lookback
+        // Must cover the full zombie threshold range (up to 365 days)
+        // Higher per-user limit to avoid prolific posters crowding out quiet users
         const filter = {
           kinds: [0, 1, 3, 6, 7, 9735], // Profiles, posts, contacts, reposts, reactions, zaps
           authors: batch,
-          limit: limit * batch.length, // Proportional limit
-          since: Math.floor(Date.now() / 1000) - 120 * 24 * 60 * 60, // 120 days - good balance
+          limit: 20 * batch.length, // 20 events per user to ensure coverage
+          since: Math.floor(Date.now() / 1000) - 365 * 24 * 60 * 60, // 365 days - matches zombie thresholds
         };
 
         console.log(

--- a/src/services/nostrService.js
+++ b/src/services/nostrService.js
@@ -2425,32 +2425,34 @@ class NostrService {
           });
         }
 
-        // Process each user in the batch with their specific relays
-        for (const pubkey of batch) {
-          const relayList = this.followsRelayLists.get(pubkey);
-          const writeRelays = this.getWriteRelays(relayList);
+        // Process batch in parallel — each user queries their own relays
+        await Promise.all(
+          batch.map(async (pubkey) => {
+            const relayList = this.followsRelayLists.get(pubkey);
+            const writeRelays = this.getWriteRelays(relayList);
 
-          if (writeRelays.length > 0) {
-            try {
-              const events = await this.fetchUserActivitySingle(
-                pubkey,
-                writeRelays,
-                5,
-              );
-              if (events.length > 0) {
-                retryResults.set(pubkey, events);
-                console.log(
-                  `🎯 SMART SUCCESS: ${pubkey.substring(0, 8)}... found on their ${writeRelays.length} preferred relays`,
+            if (writeRelays.length > 0) {
+              try {
+                const events = await this.fetchUserActivitySingle(
+                  pubkey,
+                  writeRelays,
+                  5,
+                );
+                if (events.length > 0) {
+                  retryResults.set(pubkey, events);
+                  console.log(
+                    `🎯 SMART SUCCESS: ${pubkey.substring(0, 8)}... found on their ${writeRelays.length} preferred relays`,
+                  );
+                }
+              } catch (error) {
+                console.warn(
+                  `⚠️ Smart retry failed for ${pubkey.substring(0, 8)}...:`,
+                  error.message,
                 );
               }
-            } catch (error) {
-              console.warn(
-                `⚠️ Smart retry failed for ${pubkey.substring(0, 8)}...:`,
-                error.message,
-              );
             }
-          }
-        }
+          }),
+        );
 
         processed += batch.length;
 
@@ -2474,23 +2476,35 @@ class NostrService {
    */
   async fetchUserActivitySingle(pubkey, relays, limit = 5) {
     const filter = {
-      kinds: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      kinds: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 40, 41, 42, 43, 44, 1063,
+        1311, 1984, 1985, 9734, 9735, 10000, 10001, 10002, 30000, 30001,
+        30008, 30009, 30017, 30018, 30023, 30024, 31890, 31922, 31923, 31924,
+        31925, 31989, 31990, 34550,
+      ],
       authors: [pubkey],
       limit: limit,
-      since: Math.floor((Date.now() - 180 * 24 * 60 * 60 * 1000) / 1000), // Only look back 6 months for retry
+      since: Math.floor((Date.now() - 365 * 24 * 60 * 60 * 1000) / 1000), // 1 year lookback
     };
 
     const events = [];
 
     try {
-      // Use main NDK instance but query specific relays temporarily
-      const subscription = this.ndk.subscribe(filter, { closeOnEose: true });
+      // Use the main NDK instance with per-user relay URLs
+      // NDK adds temporary relays to its pool as needed
+      const subOpts = { closeOnEose: true };
+      if (relays && relays.length > 0) {
+        subOpts.relayUrls = relays;
+      }
+
+      const subscription = this.ndk.subscribe(filter, subOpts);
 
       return new Promise((resolve) => {
         const timeout = setTimeout(() => {
           subscription.stop();
-          resolve(events);
-        }, 5000); // Shorter timeout for retry
+          events.sort((a, b) => b.created_at - a.created_at);
+          resolve(events.slice(0, limit));
+        }, 10000); // 10 second timeout
 
         subscription.on("event", (event) => {
           events.push(event);

--- a/src/views/ZombieHuntingView.vue
+++ b/src/views/ZombieHuntingView.vue
@@ -15,8 +15,8 @@
           <div v-else>
             <div class="mb-4">
               <label class="block text-gray-300 mb-2">Zombie Age Threshold</label>
-              <select 
-                v-model="selectedThreshold" 
+              <select
+                v-model="selectedThreshold"
                 class="input w-full"
                 @change="updateThreshold"
               >
@@ -26,6 +26,37 @@
                 <option value="365">Ancient Zombies (365+ days)</option>
                 <option value="all">All Zombies</option>
               </select>
+            </div>
+
+            <div v-if="selectedThreshold !== 'burned'" class="mb-4">
+              <label class="block text-gray-300 mb-2">Inactive Date Range (days)</label>
+              <div class="flex items-center gap-2">
+                <input
+                  type="number"
+                  v-model.number="dateRangeMin"
+                  min="0"
+                  placeholder="Min"
+                  class="input w-full text-sm"
+                />
+                <span class="text-gray-500">to</span>
+                <input
+                  type="number"
+                  v-model.number="dateRangeMax"
+                  min="0"
+                  placeholder="Max"
+                  class="input w-full text-sm"
+                />
+              </div>
+              <p class="text-xs text-gray-500 mt-1">
+                Filter by days since last activity. Leave empty for no limit.
+              </p>
+              <button
+                v-if="dateRangeMin || dateRangeMax"
+                @click="dateRangeMin = null; dateRangeMax = null"
+                class="text-xs text-gray-400 hover:text-gray-200 mt-1"
+              >
+                Clear range
+              </button>
             </div>
             
             <div class="mb-4">
@@ -325,6 +356,8 @@ export default {
       purgeSuccess: false,
       showCelebration: false,
       selectedThreshold: 'all',
+      dateRangeMin: null,
+      dateRangeMax: null,
       batchSize: 30,
       zombieData: null,
       lastPurgeResult: null,
@@ -414,21 +447,18 @@ export default {
         ];
       }
       
-      // Debug: log zombie filtering process
-      if (zombies.length > 0) {
-        console.log(`🎯 zombiesFiltered: ${zombies.length} zombies after filtering by threshold '${this.selectedThreshold}'`);
-        
-        // Check for our problematic users
-        const debugPrefixes = ['d4338b7c', '8c7c6312', '2e5c7e3'];
-        for (const zombie of zombies) {
-          for (const prefix of debugPrefixes) {
-            if (zombie.pubkey?.startsWith(prefix)) {
-              console.log(`🎯 Debug user ${zombie.pubkey.substring(0, 8)}... in filtered zombies:`, zombie);
-            }
-          }
-        }
+      // Apply date range filter if set
+      if (this.dateRangeMin != null || this.dateRangeMax != null) {
+        zombies = zombies.filter(z => {
+          // Burned zombies with no activity data pass through if no min is set
+          if (z.daysSinceActivity == null) return this.dateRangeMin == null;
+          const days = z.daysSinceActivity;
+          if (this.dateRangeMin != null && days < this.dateRangeMin) return false;
+          if (this.dateRangeMax != null && days > this.dateRangeMax) return false;
+          return true;
+        });
       }
-      
+
       return zombies;
     }
   },


### PR DESCRIPTION
Supersedes #50 (which was merged then reverted on main).

## Summary
- Fix `fetchUserActivitySingle` to use per-user NIP-65 write relays via `relayUrls` subscription option instead of ignoring the relay parameter
- Fix smart relay retry hanging on large follow lists by using the main NDK pool instead of creating a new NDK instance per user
- Parallelize user processing within retry batches via Promise.all
- Widen initial scan window from 120 to 365 days to match zombie threshold range
- Reduce batch size from 25 to 10 and increase per-user limit to 20 events to prevent prolific posters from crowding out quieter users
- Expand smart retry event kinds from 13 to 44 types, increase timeout from 5s to 10s
- Add date range filter (min/max days) to zombie hunt results for targeted purging

## Test plan
- [ ] Scan follows and verify previously false-positive users show correct last activity dates
- [ ] Verify smart retry progresses through all users without hanging
- [ ] Confirm scan completes in reasonable time for large follow lists (500+)
- [ ] Test date range filter narrows results correctly
- [ ] Check zombie counts are more accurate than pre-fix