### PR TITLE
Reduce zombie false positives in per-user activity recheck

### DIFF
--- a/src/services/nostrService.js
+++ b/src/services/nostrService.js
@@ -1073,18 +1073,20 @@ class NostrService {
           activityMap.set(pubkey, currentEvents.slice(0, limit));
         }
 
-        // Quick individual recheck for users in this batch with no results
-        // Batch queries can miss quiet users when prolific posters fill the limit
+        // Quick individual recheck for users in this batch with no results.
+        // Batch queries can miss quiet users when prolific posters fill the limit.
+        // Recheck filter mirrors the batch filter so we don't strip activity
+        // signals (profile updates, contacts, zaps) on the second pass.
         const missedUsers = batch.filter(
           (pk) => (activityMap.get(pk) || []).length === 0,
         );
-        if (missedUsers.length > 0 && missedUsers.length <= batchSize) {
+        if (missedUsers.length > 0) {
           const recheckPromises = missedUsers.map(async (pk) => {
             try {
               const individualEvents = await this.ndk.fetchEvents({
-                kinds: [1, 6, 7],
+                kinds: [0, 1, 3, 6, 7, 9735],
                 authors: [pk],
-                limit: 3,
+                limit: 10,
               });
               if (individualEvents && individualEvents.size > 0) {
                 const evts = Array.from(individualEvents)


### PR DESCRIPTION
## Summary

User report after v0.9 release: a hunt wanted to clear a "large part of my follow list, that included many people who post regularly." Investigation traced the issue to the per-user activity recheck in `nostrService.getProfilesActivity` being narrower than the initial batch query in three ways.

## Changes

`src/services/nostrService.js` (lines 1078–1104):

| Aspect | Initial batch | Recheck (before) | Recheck (after) |
|---|---|---|---|
| Event kinds | `[0, 1, 3, 6, 7, 9735]` | `[1, 6, 7]` | **`[0, 1, 3, 6, 7, 9735]`** |
| Per-user limit | 20 | 3 | **10** |
| Trigger guard | n/a | `missedUsers.length <= batchSize` (dead code) | **removed** |

### Why each matters

- **Wider kinds** — profile updates (0), contact list edits (3), and zaps (9735) are real activity signals. The narrower recheck was silently ignoring them, so users whose recent activity happened in those kinds got marked dormant.
- **Higher limit** — relays don't guarantee ordering. Asking for only 3 events and then sorting client-side meant we'd sometimes get 3 *old* events and miss a recent one. Bumping to 10 matches the default activity cap used downstream.
- **Removed dead gate** — `missedUsers` is filtered from `batch`, so `missedUsers.length` was always ≤ `batchSize`. The check did nothing but invited future regressions if `batchSize` changed.

## Follow-up (deferred)

The bigger remaining gap is that activity queries hit PvZ's 6 default relays only. We should also query each user's NIP-65 declared write relays so we catch posts on relays we don't otherwise scan. That's a larger refactor — landing it after measuring the impact of these fixes.

## Test plan

- [ ] `npm test` passes (follow-recovery Vitest suite — confirms no regression)
- [ ] `npm run build` clean
- [ ] Run a zombie scan against a known follow set; compare zombie counts pre/post deploy
- [ ] Specifically verify accounts known to post regularly are not classified as ancient