### PR TITLE
Recheck users with stale activity, not just missing activity

### DIFF
--- a/src/services/nostrService.js
+++ b/src/services/nostrService.js
@@ -1073,15 +1073,30 @@ class NostrService {
           activityMap.set(pubkey, currentEvents.slice(0, limit));
         }
 
-        // Quick individual recheck for users in this batch with no results.
-        // Batch queries can miss quiet users when prolific posters fill the limit.
-        // Recheck filter mirrors the batch filter so we don't strip activity
-        // signals (profile updates, contacts, zaps) on the second pass.
-        const missedUsers = batch.filter(
-          (pk) => (activityMap.get(pk) || []).length === 0,
-        );
-        if (missedUsers.length > 0) {
-          const recheckPromises = missedUsers.map(async (pk) => {
+        // Per-user recheck for users whose batch results are missing or stale.
+        // Batch queries can let prolific posters crowd out quieter users'
+        // recent activity even when the relay has it. A single-user query has
+        // no such crowding and reliably returns each user's most recent events.
+        //
+        // We recheck:
+        //   (a) users with zero events in the batch (would be misclassified ancient)
+        //   (b) users whose newest event is older than RECHECK_STALE_THRESHOLD
+        //       (might be misclassified as a zombie when they're actually active)
+        const RECHECK_STALE_THRESHOLD_DAYS = 60;
+        const staleCutoff =
+          Math.floor(Date.now() / 1000) - RECHECK_STALE_THRESHOLD_DAYS * 86400;
+
+        const usersToRecheck = batch.filter((pk) => {
+          const events = activityMap.get(pk) || [];
+          if (events.length === 0) return true; // (a) no events
+          return events[0].created_at < staleCutoff; // (b) newest is stale
+        });
+
+        if (usersToRecheck.length > 0) {
+          console.log(
+            `🔁 Batch ${batchNum}: rechecking ${usersToRecheck.length} user(s) (missing or stale)`,
+          );
+          const recheckPromises = usersToRecheck.map(async (pk) => {
             try {
               const individualEvents = await this.ndk.fetchEvents({
                 kinds: [0, 1, 3, 6, 7, 9735],
@@ -1098,7 +1113,16 @@ class NostrService {
                     content: e.content,
                     kind: e.kind,
                   }));
-                activityMap.set(pk, evts);
+                // Only overwrite if the recheck found something newer than what
+                // we already had — protects against the recheck returning only
+                // older events than the batch already cached.
+                const existing = activityMap.get(pk) || [];
+                if (
+                  existing.length === 0 ||
+                  evts[0].created_at > existing[0].created_at
+                ) {
+                  activityMap.set(pk, evts);
+                }
               }
             } catch (_) {}
           });


### PR DESCRIPTION
## Summary

Follow-up to PR #53 (v0.9.1). The recheck added in #53 only fires when the batch returns **zero** events for a user. But the more common false-positive pattern is the batch returning **stale** events — older entries while the user has recent activity on a relay that got crowded out by the batch's per-query event limit.

### Real-world case that motivated this

A reporter flagged `npub180z8ywyfg56sk78unedkn6p0d68clchwzj2nhq2309sw8gywldcsne5tax` as showing "5 months" inactive when they posted 2 weeks ago. Per-relay investigation:

| Relay | Most recent activity |
|---|---|
| **wss://nos.lol** (PvZ default) | **kind:1, 16 days ago** |
| relay.primal.net | kind:3, **146 days ago** ← what PvZ found |
| purplepag.es | kind:3, 146 days ago |
| relay.nos.social | kind:3, 146 days ago |

The batch query returned the 146-day kind:3 events from 3 relays before the 16-day kind:1 came through from nos.lol. With `activityMap[pk]` non-empty, the v0.9.1 recheck skipped them. Result: classified as "5 months" inactive.

## Fix

`src/services/nostrService.js` recheck logic:

- **Also recheck users whose newest entry is older than 60 days.** 60d is well below the 90d fresh-zombie threshold — covers any user who *might* be misclassified without rechecking already-obviously-active users.
- **Guard overwrites:** if the recheck somehow returns only older events than what the batch already cached, don't downgrade `activityMap[pk]`.
- **Add a log line** showing how many users got rechecked per batch, for visibility.

## Test plan

- [ ] `npm test` passes
- [ ] `npm run build` clean
- [ ] Run a real scan against a follow set including known-active accounts
- [ ] Specifically verify the npub above is no longer classified as "5 months" inactive
- [ ] Watch console for `🔁 Batch N: rechecking K user(s)` — should fire for any batch with stale users

## Follow-up still pending

Bigger gap: PvZ's activity scan queries its 6 default relays only. For users whose recent posts are scattered across niche relays (or who post primarily off-defaults), we still miss them. Task tracked: query each user's NIP-65 declared write relays for activity.