### PR TITLE
Wire purge settings to NIP-78 relay sync

### DIFF
--- a/src/services/relayStorage.js
+++ b/src/services/relayStorage.js
@@ -7,7 +7,6 @@
  * NIP-78: https://github.com/nostr-protocol/nips/blob/master/78.md
  */
 
-import { NDKEvent } from '@nostr-dev-kit/ndk';
 import nostrService from './nostrService';
 
 class RelayStorage {
@@ -28,9 +27,8 @@ class RelayStorage {
     try {
       await nostrService.initialize();
 
-      const signer = nostrService.getSigner();
-      if (!signer) {
-        throw new Error('No signer available. Please connect with a browser extension.');
+      if (!nostrService.isSigningReady()) {
+        throw new Error('No signer available. Please connect your Nostr account.');
       }
 
       // Add timestamp to data
@@ -39,14 +37,12 @@ class RelayStorage {
         timestamp: Math.floor(Date.now() / 1000)
       };
 
-      // Create the event
-      const event = new NDKEvent(nostrService.ndk);
-      event.kind = this.KIND;
-      event.tags = [['d', `${this.APP_PREFIX}:${dTag}`]];
+      const tags = [['d', `${this.APP_PREFIX}:${dTag}`]];
+      let content;
 
       // Encrypt if requested
       if (encrypted) {
-        const content = JSON.stringify(dataWithTimestamp);
+        const plaintext = JSON.stringify(dataWithTimestamp);
         const pubkey = nostrService.pubkey;
 
         if (!pubkey) {
@@ -54,18 +50,21 @@ class RelayStorage {
         }
 
         // Encrypt to self, preferring NIP-44 with NIP-04 fallback
-        const { ciphertext, algorithm } = await nostrService.encryptData(content, pubkey);
-        event.content = ciphertext;
-        event.tags.push(['enc', algorithm]);
+        const { ciphertext, algorithm } = await nostrService.encryptData(plaintext, pubkey);
+        content = ciphertext;
+        tags.push(['enc', algorithm]);
       } else {
-        event.content = JSON.stringify(dataWithTimestamp);
+        content = JSON.stringify(dataWithTimestamp);
       }
 
-      // Sign the event
-      await event.sign(signer);
-
-      // Convert NDKEvent to plain object for publishing
-      const signedEvent = event.rawEvent();
+      // Sign with whichever method the user is connected with (nsec/NIP-46/NIP-07).
+      // NIP-46 has its own transport-size fallback to NIP-07 built into nip46Service.
+      const signedEvent = await nostrService.signEventWithCurrentMethod({
+        kind: this.KIND,
+        created_at: Math.floor(Date.now() / 1000),
+        tags,
+        content,
+      });
 
       // Publish using nostrService's publishEventToRelays method
       const targetRelays = relays || this._getPublishRelays();
@@ -80,7 +79,7 @@ class RelayStorage {
       nostrService.relays = originalRelays;
 
       console.log(`[RelayStorage] Published ${dTag} to ${publishResults.successful}/${publishResults.total} relay(s)`, {
-        eventId: event.id,
+        eventId: signedEvent.id,
         encrypted
       });
 
@@ -88,7 +87,7 @@ class RelayStorage {
         throw new Error('Failed to publish to any relays');
       }
 
-      return event.id;
+      return signedEvent.id;
     } catch (error) {
       console.error(`[RelayStorage] Failed to publish ${dTag}:`, error);
       throw error;
@@ -167,8 +166,7 @@ class RelayStorage {
     try {
       await nostrService.initialize();
 
-      const signer = nostrService.getSigner();
-      if (!signer) {
+      if (!nostrService.isSigningReady()) {
         throw new Error('No signer available');
       }
 
@@ -187,16 +185,13 @@ class RelayStorage {
         return null;
       }
 
-      // Create deletion event (kind 5)
-      const deletionEvent = new NDKEvent(nostrService.ndk);
-      deletionEvent.kind = 5;
-      deletionEvent.content = `Deleting ${this.APP_PREFIX}:${dTag}`;
-      deletionEvent.tags = Array.from(events).map(event => ['e', event.id]);
-
-      await deletionEvent.sign(signer);
-
-      // Convert NDKEvent to plain object for publishing
-      const signedEvent = deletionEvent.rawEvent();
+      // Create deletion event (kind 5), signed with whichever method the user is connected with
+      const signedEvent = await nostrService.signEventWithCurrentMethod({
+        kind: 5,
+        created_at: Math.floor(Date.now() / 1000),
+        content: `Deleting ${this.APP_PREFIX}:${dTag}`,
+        tags: Array.from(events).map(event => ['e', event.id]),
+      });
 
       // Publish using nostrService's publishEventToRelays method
       const targetRelays = relays || this._getPublishRelays();
@@ -211,12 +206,12 @@ class RelayStorage {
       nostrService.relays = originalRelays;
 
       console.log(`[RelayStorage] Deleted ${dTag}`, {
-        deletionEventId: deletionEvent.id,
-        deletedEvents: deletionEvent.tags.length,
+        deletionEventId: signedEvent.id,
+        deletedEvents: signedEvent.tags.length,
         publishedTo: `${publishResults.successful}/${publishResults.total} relays`
       });
 
-      return deletionEvent.id;
+      return signedEvent.id;
     } catch (error) {
       console.error(`[RelayStorage] Failed to delete ${dTag}:`, error);
       throw error;

--- a/src/services/settings/batchSettings.js
+++ b/src/services/settings/batchSettings.js
@@ -63,6 +63,9 @@ class BatchSettings {
 
       // Save to localStorage
       this.saveToLocalStorage();
+      // Mark this as the freshest known state so a later sync doesn't mistake
+      // stale relay data for newer and silently revert this change.
+      this.setLocalTimestamp(Math.floor(Date.now() / 1000));
 
       // Publish to relay if requested
       if (publish) {

--- a/src/services/settings/zombieClassificationSettings.js
+++ b/src/services/settings/zombieClassificationSettings.js
@@ -59,6 +59,9 @@ class ZombieClassificationSettings {
 
       // Save to localStorage
       this.saveToLocalStorage();
+      // Mark this as the freshest known state so a later sync doesn't mistake
+      // stale relay data for newer and silently revert this change.
+      this.setLocalTimestamp(Math.floor(Date.now() / 1000));
 
       // Publish to relay if requested
       if (publish) {

--- a/src/services/zombieService.js
+++ b/src/services/zombieService.js
@@ -1,6 +1,8 @@
 import { differenceInDays } from "date-fns";
 import nostrService from "./nostrService";
 import immunityService from "./immunityService";
+import zombieClassificationSettings from "./settings/zombieClassificationSettings";
+import batchSettings from "./settings/batchSettings";
 import localforage from "localforage";
 
 // Configure localforage
@@ -10,22 +12,23 @@ localforage.config({
 });
 
 class ZombieService {
-  constructor() {
-    this.zombieThresholds = {
-      fresh: 90, // 3 months minimum before considering zombie
-      rotting: 180, // 6 months for "rotting" zombie
-      ancient: 365, // 1 year for "ancient" zombie (more conservative)
-    };
-    this.batchSize = 30; // Default batch size for unfollows
+  // Thresholds and batch size are delegated to zombieClassificationSettings /
+  // batchSettings (NIP-78-backed) so a value loaded from localStorage or
+  // synced from a relay on login actually drives classification, instead of
+  // this service holding its own disconnected in-memory copy.
+  get zombieThresholds() {
+    return zombieClassificationSettings.getSettings();
+  }
+
+  get batchSize() {
+    return batchSettings.getSettings().batchSize;
   }
 
   /**
    * Set custom thresholds for zombie classification
    */
   setThresholds(fresh, rotting, ancient) {
-    this.zombieThresholds.fresh = fresh || this.zombieThresholds.fresh;
-    this.zombieThresholds.rotting = rotting || this.zombieThresholds.rotting;
-    this.zombieThresholds.ancient = ancient || this.zombieThresholds.ancient;
+    return zombieClassificationSettings.updateSettings({ fresh, rotting, ancient });
   }
 
   /**
@@ -33,7 +36,7 @@ class ZombieService {
    */
   setBatchSize(size) {
     if (size > 0 && size <= 100) {
-      this.batchSize = size;
+      return batchSettings.updateSettings({ batchSize: size });
     }
   }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -822,6 +822,24 @@ export default {
       return getVersionSync();
     }
   },
+  watch: {
+    // When a relay sync completes, thresholds/batch size may have just been
+    // pulled from the relay into the underlying services. The form snapshots
+    // those values once at mount, so on a fresh device it can briefly show
+    // defaults until the async sync lands. Re-read just those display fields
+    // when a sync finishes — scoped narrowly so we never clobber an unsaved
+    // relay-list edit or other in-progress form input.
+    'syncStatus.isSyncing'(isSyncing, wasSyncing) {
+      if (wasSyncing && !isSyncing) {
+        this.thresholds = {
+          fresh: zombieService.zombieThresholds.fresh,
+          rotting: zombieService.zombieThresholds.rotting,
+          ancient: zombieService.zombieThresholds.ancient
+        };
+        this.batchSize = zombieService.batchSize;
+      }
+    }
+  },
   methods: {
     goToZombieHunting() {
       this.$router.push('/hunt');


### PR DESCRIPTION
## Problem
Zombie classification thresholds and unfollow batch size were plain in-memory properties on `zombieService`, reset to defaults on every page load. The app already shipped fully-built NIP-78 settings services (`zombieClassificationSettings`, `batchSettings`) that persist to localStorage and sync to relays on login — but nothing ever read from or wrote to them, so they were dead code.

Separately, `relayStorage.js` (the NIP-78 publish/delete layer) signed via `nostrService.getSigner()`, which only returns a signer for NIP-07 browser extensions. NIP-78 publishing was therefore silently broken for NIP-46 (Amber/Primal) and nsec users — it never attempted remote signing at all, regardless of event size.

## Changes
- **`zombieService`**: `zombieThresholds` and `batchSize` are now live getters delegating to the settings services; `setThresholds()`/`setBatchSize()` delegate to their `updateSettings()` (which persists + publishes). `SettingsView` needed no changes — it already called these accessors. Single source of truth, so a value loaded from localStorage or synced from a relay now actually drives classification.
- **`relayStorage`**: `publish()`/`delete()` now sign via `signEventWithCurrentMethod()`, so NIP-78 works for nsec/NIP-46/NIP-07. This inherits `nip46Service`'s existing 64KB transport fallback to NIP-07 for free.

## Follow-up fixes (in this branch)
- `updateSettings()` never bumped the local sync timestamp, so the next sync compared a fresh edit against an older relay event, decided the relay was "newer", and silently reverted the change. Now stamps the local timestamp on save.
- `SettingsView` snapshotted threshold/batch values once at mount, so on a fresh device it could show defaults until the async login sync landed, then require a manual refresh. Added a `watch` on `syncStatus.isSyncing` that re-reads just those fields when a sync completes — scoped so it never clobbers an unsaved relay-list or other in-progress edit.

## Testing
- `npm run build` and `npm test` pass.
- Manual: changed a threshold, confirmed it persists across reload and across sessions (localStorage + relay). Confirmed the stale-form-display and revert-on-sync bugs are fixed.

Targets **v0.9.4** (version bump lands separately once the v0.9.4 PRs are merged).